### PR TITLE
Add escrow tracking and vesting_duration assert

### DIFF
--- a/contracts/VestingEscrowFactory.vy
+++ b/contracts/VestingEscrowFactory.vy
@@ -65,6 +65,7 @@ def deploy_vesting_contract(
     @param vesting_start Epoch time when tokens begin to vest
     """
     assert cliff_length <= vesting_duration  # dev: incorrect vesting cliff
+    assert vesting_duration > 0  # dev: duration must be > 0
     escrow: address = create_forwarder_to(self.target)
     assert ERC20(token).transferFrom(msg.sender, self, amount)  # dev: funding failed
     assert ERC20(token).approve(escrow, amount)  # dev: approve failed

--- a/contracts/VestingEscrowFactory.vy
+++ b/contracts/VestingEscrowFactory.vy
@@ -33,8 +33,8 @@ event VestingEscrowCreated:
 
 
 target: public(address)
-contracts: public(HashMap[address, address[1000000000]])
-contracts_list_pointer: public(HashMap[address, uint256])
+escrows: public(address[1000000000000])
+escrows_length: public(uint256)
 
 @external
 def __init__(target: address):
@@ -78,9 +78,7 @@ def deploy_vesting_contract(
         vesting_start + vesting_duration,
         cliff_length,
     )
-    self.contracts[msg.sender][self.contracts_list_pointer[msg.sender]] = escrow
-    self.contracts_list_pointer[msg.sender] += 1
-    self.contracts[recipient][self.contracts_list_pointer[recipient]] = escrow
-    self.contracts_list_pointer[recipient] += 1
+    self.escrows[self.escrows_length] = escrow
+    self.escrows_length += 1
     log VestingEscrowCreated(msg.sender, token, recipient, escrow, amount, vesting_start, vesting_duration, cliff_length)
     return escrow

--- a/contracts/VestingEscrowFactory.vy
+++ b/contracts/VestingEscrowFactory.vy
@@ -33,6 +33,8 @@ event VestingEscrowCreated:
 
 
 target: public(address)
+contracts: public(HashMap[address, address[1000000000]])
+contracts_list_pointer: public(HashMap[address, uint256])
 
 @external
 def __init__(target: address):
@@ -43,7 +45,6 @@ def __init__(target: address):
     @param target `VestingEscrowSimple` contract address
     """
     self.target = target
-
 
 @external
 def deploy_vesting_contract(
@@ -75,5 +76,9 @@ def deploy_vesting_contract(
         vesting_start + vesting_duration,
         cliff_length,
     )
+    self.contracts[msg.sender][self.contracts_list_pointer[msg.sender]] = escrow
+    self.contracts_list_pointer[msg.sender] += 1
+    self.contracts[recipient][self.contracts_list_pointer[recipient]] = escrow
+    self.contracts_list_pointer[recipient] += 1
     log VestingEscrowCreated(msg.sender, token, recipient, escrow, amount, vesting_start, vesting_duration, cliff_length)
     return escrow

--- a/contracts/VestingEscrowFactory.vy
+++ b/contracts/VestingEscrowFactory.vy
@@ -46,6 +46,7 @@ def __init__(target: address):
     """
     self.target = target
 
+
 @external
 def deploy_vesting_contract(
     token: address,


### PR DESCRIPTION
## Changes only affect factory
All the changes are applied only in the factory contract, but all the logic that holds and handles money is in the other contract, `VestingEscrowSimple.vy`, thus the changes are extremely safe since factory only handles instantiation of new contracts.

## vesting_duration assert
As mentioned by [0xalpharush from TrailOfBits on twitter](https://twitter.com/0xalpharush/status/1532862869880045568), there's a very extreme edge_case where if vesting_duration is 0 and admin renounces ownership, funds would get locked in the contract. This update prevents that by adding a check on new escrow creation to force `vesting_duration > 0` since it makes no sense for it to be 0, as then funds can only be clawed back by admin and they will never vest.

## escrows tracking
There are chains where getting all events that have been emitted in the lifespan of a contract is very difficult or takes a lot of time, so to help in those cases we add an array that tracks all instantiated escrows, making it possible to query everything needed from state.